### PR TITLE
Implement WebSocket-based libp2p Relay v2 server for Render deployment

### DIFF
--- a/cmd/CLIENT/khush.txt
+++ b/cmd/CLIENT/khush.txt
@@ -1,1 +1,0 @@
-Ha Sike you got j-baited!

--- a/internal/client/webrtc.go
+++ b/internal/client/webrtc.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pion/webrtc/v3"
 )
 
@@ -42,6 +43,7 @@ const (
 )
 
 type SimpleWebRTCPeer struct {
+	ID              peer.ID
 	pc              *webrtc.PeerConnection
 	dc              *webrtc.DataChannel
 	onMessage       func(msg webrtc.DataChannelMessage, peer *SimpleWebRTCPeer)
@@ -192,6 +194,9 @@ func (p *SimpleWebRTCPeer) HandleAnswer(answerStr string) error {
 	return p.pc.SetRemoteDescription(answer)
 }
 
+// Checks if the WebRTC data channel is open
+// Converts any Go data (struct/map/slice/etc.) into JSON
+// Sends that JSON string to the other peer using WebRTC's data channel
 func (p *SimpleWebRTCPeer) SendJSON(v interface{}) error {
 	if p.dc == nil || p.dc.ReadyState() != webrtc.DataChannelStateOpen {
 		return fmt.Errorf("data channel is not open")


### PR DESCRIPTION
This PR sets up a dedicated libp2p Relay v2 server hosted on Render to support peer connectivity in restricted NAT/firewall environments. The relay acts as a middle layer to facilitate connections when direct peer-to-peer dialing is not possible.

Key Features Implemented

1. Relay Host Initialization

-- Uses go-libp2p to create a host instance.

-- Configured with:

-- Noise protocol for secure communication.

-- WebSocket transport for browser compatibility and easier deployment on Render.

2. Dynamic Address Binding

-- Reads the port from Render’s $PORT environment variable (defaults to 443).

-- Listens internally on /ip4/0.0.0.0/tcp/<port>/ws.

3. Public Address Advertising

Uses the RENDER_EXTERNAL_URL environment variable to generate a public /dns4/.../wss address.

Ensures peers outside the container can discover and connect to the relay.

4. Relay v2 Service

Enables circuit-relay v2, allowing peers to request reservations and relay traffic via /p2p-circuit.

This is critical for enabling NAT traversal in the Torrentium network.

5. Logging and Debug Information

-- Logs peer ID on startup.

-- Logs all advertised multiaddrs in /dns4/.../wss/p2p/<peerID> format.

-- Provides clear confirmation that the relay has started successfully.

Impact

-- NAT Traversal Support: Enables peers behind restrictive NAT/firewall setups to communicate through this relay.

-- Improved Network Resilience: Ensures peers can still find and connect to each other even without direct connectivity.

-- Foundation for Advanced Features: Future enhancements (peer connection logging, metrics, monitoring) can be built on top of this relay service.
